### PR TITLE
Don't run all scripted tests for sbt-lm-coursier on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ environment:
 build_script:
   - ps: Start-Job -filepath .\metadata\scripts\start-it-auth-server.ps1 -ArgumentList $pwd\metadata, $env:TEST_REPOSITORY_HOST, $env:TEST_REPOSITORY_PORT, $env:TEST_REPOSITORY_USER, $env:TEST_REPOSITORY_PASSWORD
 test_script:
-  - sbt ++2.12.7 "sbt-lm-coursier/scripted shared-1/*" "sbt-lm-coursier/scripted shared-2/*" sbt-coursier/scripted sbt-shading/scripted
+  - sbt ++2.12.7 "sbt-lm-coursier/scripted shared-2/simple" sbt-coursier/scripted sbt-shading/scripted
 branches:
   only:
     - master


### PR DESCRIPTION
Builds often take more than one hour (and are stopped by Appveyor)