### PR TITLE
Log output of dependency information tasks instead of printing

### DIFF
--- a/modules/sbt-coursier/src/main/scala/coursier/sbtcoursier/DisplayTasks.scala
+++ b/modules/sbt-coursier/src/main/scala/coursier/sbtcoursier/DisplayTasks.scala
@@ -83,8 +83,7 @@ object DisplayTasks {
 
     val resolutions = coursierResolutionTask(sbtClassifiers, ignoreArtifactErrors).value
     for (ResolutionResult(subGraphConfigs, resolution, dependencies) <- resolutions) {
-      // use sbt logging?
-      println(
+      streams.value.log.info(
         s"$projectName (configurations ${subGraphConfigs.toVector.sorted.mkString(", ")})" + "\n" +
           Print.dependencyTree(
             resolution,
@@ -125,7 +124,7 @@ object DisplayTasks {
           reverse = true,
           colors = !sys.props.get("sbt.log.noformat").toSeq.contains("true")
         )
-      println(strToPrint)
+      streams.value.log.info(strToPrint)
       result.append(strToPrint)
       result.append("\n")
     }


### PR DESCRIPTION
This allows use of "last-grep" to filter the output.

Fixes https://github.com/coursier/coursier/issues/1191