### PR TITLE
Shade JLine and JAnsi

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,9 @@ lazy val `lm-coursier-shaded` = project
     shadeNamespaces ++= Set(
       "coursier",
       "shapeless",
-      "argonaut"
+      "argonaut",
+      "jline",
+      "org.fusesource.jansi",
     ),
     libraryDependencies ++= Seq(
       "io.get-coursier" %% "coursier" % coursierVersion0 % "shaded",


### PR DESCRIPTION
Ref coursier/coursier#1283

Starting 2.0.0-RC3-2, I am seeing following runtime error:

```
[info] [error] java.lang.NoClassDefFoundError: Could not initialize class org.fusesource.jansi.AnsiOutputStream
[info] [error] 	at jline.internal.Ansi.stripAnsi(Ansi.java:28)
[info] [error] 	at jline.console.ConsoleReader.setPrompt(ConsoleReader.java:499)
[info] [error] 	at jline.console.ConsoleReader.readLine(ConsoleReader.java:2425)
[info] [error] 	at jline.console.ConsoleReader.readLine(ConsoleReader.java:2378)
[info] [error] 	at jline.console.ConsoleReader.readLine(ConsoleReader.java:2366)
```

This is likely due to the conflict between JAnsi 1.18 and JAnsi 1.12 included into JLine 2 that sbt is using. This adds more shading to workaround this issue.