### PR TITLE
make scala-tool an exception not the rule

### DIFF
--- a/modules/sbt-coursier/src/sbt-test/shared-1/inter-project/build.sbt
+++ b/modules/sbt-coursier/src/sbt-test/shared-1/inter-project/build.sbt
@@ -30,3 +30,12 @@ lazy val b = project
     version := "0.0.1",
     libraryDependencies += "com.github.alexarchambault" %% "argonaut-shapeless_6.2" % "1.2.0-M11"
   )
+
+lazy val c = project
+  .dependsOn(b % Configurations.CompilerPlugin)
+  .settings(sharedSettings)
+  .settings(
+    organization := "com.pany",
+    name := "c",
+    version := "0.0.1"
+  )

--- a/modules/sbt-coursier/src/sbt-test/shared-1/inter-project/test
+++ b/modules/sbt-coursier/src/sbt-test/shared-1/inter-project/test
@@ -1,3 +1,4 @@
 $ delete output
 > b/run
 $ exists output
+> c/compile


### PR DESCRIPTION
Fixes https://github.com/coursier/coursier/issues/1442
Fixes https://github.com/coursier/coursier/issues/1340
Ref https://github.com/coursier/sbt-coursier/pull/136

This treats `ScalaTool` (and only `ScalaTool`) as a sandbox configuration isolated from other subprojects. Likely this behavior is needed only for `ScalaTool` configuration where the scala-xml build's `ScalaTool` configuration transitively loops back to scala-xml's `Compile` artifacts. In most other cases, it's desirable to allow "x->compile" relationship.