### PR TITLE
Add a scripted test for "cp order"

### DIFF
--- a/modules/sbt-coursier/src/sbt-test/sbt-lm-coursier/cp-order/build.sbt
+++ b/modules/sbt-coursier/src/sbt-test/sbt-lm-coursier/cp-order/build.sbt
@@ -1,0 +1,4 @@
+scalaVersion := "2.12.8"
+
+libraryDependencies += "com.typesafe.play" %% "play-test" % "2.8.0-RC1" % Test // worked around in 2.8.0
+libraryDependencies += "org.scalatest"     %% "scalatest" % "3.0.8"     % Test

--- a/modules/sbt-coursier/src/sbt-test/sbt-lm-coursier/cp-order/project/plugins.sbt
+++ b/modules/sbt-coursier/src/sbt-test/sbt-lm-coursier/cp-order/project/plugins.sbt
@@ -1,0 +1,13 @@
+addSbtPlugin {
+
+  val name = sys.props.getOrElse(
+    "plugin.name",
+    sys.error("plugin.name Java property not set")
+  )
+  val version = sys.props.getOrElse(
+    "plugin.version",
+    sys.error("plugin.version Java property not set")
+  )
+
+  "io.get-coursier" % name % version
+}

--- a/modules/sbt-coursier/src/sbt-test/sbt-lm-coursier/cp-order/src/test/scala/t/UnitSpec.scala
+++ b/modules/sbt-coursier/src/sbt-test/sbt-lm-coursier/cp-order/src/test/scala/t/UnitSpec.scala
@@ -1,0 +1,20 @@
+package t
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{ MustMatchers, WordSpec }
+
+class UnitSpec extends WordSpec with MustMatchers {
+  def conf = ConfigFactory.defaultReference()
+
+  "Config" should {
+    "return Akka HTTP server provider" in {
+      val serverProvider = conf.getString("play.server.provider")
+      serverProvider mustBe "play.core.server.AkkaHttpServerProvider"
+    }
+
+    "be able to load Netty settings" in {
+      val nettyTransport = conf.getString("play.server.netty.transport")
+      nettyTransport mustBe "jdk"
+    }
+  }
+}

--- a/modules/sbt-coursier/src/sbt-test/sbt-lm-coursier/cp-order/test
+++ b/modules/sbt-coursier/src/sbt-test/sbt-lm-coursier/cp-order/test
@@ -1,0 +1,4 @@
+# https://github.com/coursier/coursier/issues/1466
+> test
+> set csrConfiguration ~= (_.withClasspathOrder(false))
+-> test

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -3,7 +3,7 @@ import java.util.Locale
 
 import sbt._
 import sbt.Keys._
-import sbt.ScriptedPlugin.autoImport.{scriptedBufferLog, scriptedLaunchOpts}
+import sbt.ScriptedPlugin.autoImport.{scriptedBufferLog, scriptedLaunchOpts, scriptedSbt}
 
 import com.jsuereth.sbtpgp._
 import coursier.ShadingPlugin.autoImport.{Shading, shadingNamespace}
@@ -12,7 +12,7 @@ object Settings {
 
   def scala212 = "2.12.10"
 
-  def sbt10Version = "1.0.2"
+  def targetSbtVersion = "1.2.8" // the version of sbt to compile against
 
   private lazy val isAtLeastScala213 = Def.setting {
     import Ordering.Implicits._
@@ -51,8 +51,6 @@ object Settings {
   lazy val plugin =
     shared ++
     Seq(
-      // https://github.com/sbt/sbt/issues/5049#issuecomment-528960415
-      dependencyOverrides := "org.scala-sbt" % "sbt" % "1.2.8" :: Nil,
       scriptedLaunchOpts ++= Seq(
         "-Xmx1024M",
         "-Dplugin.name=" + name.value,
@@ -62,7 +60,8 @@ object Settings {
       ),
       scriptedBufferLog := false,
       sbtPlugin := true,
-      sbtVersion.in(pluginCrossBuild) := sbt10Version
+      sbtVersion.in(pluginCrossBuild) := targetSbtVersion, // sbt/sbt#5049
+      scriptedSbt := sbtVersion.value, // run scripted with the build's sbt version
     )
 
   lazy val shading =


### PR DESCRIPTION
Refs coursier/coursier#1466

The fact that the first part of the test (`> test`) passes, while it didn't for me when I tested the same test case in a custom build of sbt using lm-coursier-shaded 2.0.0-RC5-3 indicates to me that the scripted test is doing something that contaminates the test.

Also, if I revert #174 it still passes...  So, as a safe-guard, I added the second part: with "classpath order" disabled it should fail.