### PR TITLE
expose ttl, verbosityLevel, checksums, cachePolicies to SBT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val `lm-coursier` = project
       // is ignored).
       "org.scala-sbt" %% "librarymanagement-ivy" % "1.3.1",
       "org.scalatest" %% "scalatest" % "3.1.1" % Test
-    ),
+    )
   )
 
 lazy val `lm-coursier-shaded` = project

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val `lm-coursier` = project
       // is ignored).
       "org.scala-sbt" %% "librarymanagement-ivy" % "1.3.1",
       "org.scalatest" %% "scalatest" % "3.1.1" % Test
-    )
+    ),
   )
 
 lazy val `lm-coursier-shaded` = project

--- a/modules/lm-coursier/src/main/scala/lmcoursier/CoursierConfiguration.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/CoursierConfiguration.scala
@@ -3,10 +3,13 @@ package lmcoursier
 import java.io.File
 
 import dataclass.data
+import coursier.cache.CacheDefaults
 import lmcoursier.credentials.Credentials
-import lmcoursier.definitions.{Authentication, CacheLogger, Module, ModuleMatchers, Project, Reconciliation, Strict}
+import lmcoursier.definitions.{Authentication, CacheLogger, CachePolicy, FromCoursier, Module, ModuleMatchers, Project, Reconciliation, Strict}
 import sbt.librarymanagement.Resolver
 import xsbti.Logger
+
+import scala.concurrent.duration.Duration
 
 @data class CoursierConfiguration(
   log: Option[Logger] = None,
@@ -41,6 +44,11 @@ import xsbti.Logger
   reconciliation: Vector[(ModuleMatchers, Reconciliation)] = Vector.empty,
   @since
   classpathOrder: Boolean = true,
+  @since
+  verbosityLevel: Int = 0,
+  ttl: Option[Duration] = CacheDefaults.ttl,
+  checksums: Vector[Option[String]] = CacheDefaults.checksums.to[Vector],
+  cachePolicies: Vector[CachePolicy] = CacheDefaults.cachePolicies.to[Vector].map(FromCoursier.cachePolicy),
 ) {
 
   def withLog(log: Logger): CoursierConfiguration =
@@ -65,6 +73,8 @@ import xsbti.Logger
     withFollowHttpToHttpsRedirections(Some(true))
   def withStrict(strict: Strict): CoursierConfiguration =
     withStrict(Some(strict))
+  def withTtl(ttl: Duration): CoursierConfiguration =
+    withTtl(Some(ttl))
 }
 
 object CoursierConfiguration {
@@ -110,6 +120,6 @@ object CoursierConfiguration {
       authenticationByRepositoryId,
       credentials,
       Option(logger),
-      Option(cache),
-    )
+      Option(cache)
+    ) /* no need to touch this 'apply'; @data above is doing the hard work */
 }

--- a/modules/lm-coursier/src/main/scala/lmcoursier/CoursierDependencyResolution.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/CoursierDependencyResolution.scala
@@ -4,7 +4,7 @@ import java.io.File
 
 import coursier.{Organization, Resolution, organizationString}
 import coursier.core.{Classifier, Configuration}
-import coursier.cache.CacheDefaults
+import coursier.cache.{CacheDefaults, CachePolicy}
 import coursier.util.Artifact
 import coursier.internal.Typelevel
 import lmcoursier.definitions.ToCoursier
@@ -79,13 +79,13 @@ class CoursierDependencyResolution(conf: CoursierConfiguration) extends Dependen
 
     val extraProjects = conf.extraProjects.map(ToCoursier.project)
 
-    val verbosityLevel = 0
+    val verbosityLevel = conf.verbosityLevel
 
-    val ttl = CacheDefaults.ttl
+    val ttl = conf.ttl
     val loggerOpt = conf.logger.map(ToCoursier.cacheLogger)
     val cache = conf.cache.getOrElse(CacheDefaults.location)
-    val cachePolicies = CacheDefaults.cachePolicies
-    val checksums = CacheDefaults.checksums
+    val cachePolicies = conf.cachePolicies.map(ToCoursier.cachePolicy)
+    val checksums = conf.checksums
     val projectName = "" // used for logging only…
 
     val ivyProperties = ResolutionParams.defaultIvyProperties(conf.ivyHome)

--- a/modules/lm-coursier/src/main/scala/lmcoursier/definitions/CachePolicy.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/definitions/CachePolicy.scala
@@ -1,0 +1,72 @@
+package lmcoursier.definitions
+
+sealed abstract class CachePolicy extends Serializable
+
+object CachePolicy {
+  /* NOTE: the following comments are copied from coursier.cache.CachePolicy for the benefit of users within an IDE
+  that reads the javadocs. Please keep in sync from the original ADT.
+   */
+  
+  /** Only pick local files, possibly from the cache. Don't try to download anything. */
+  case object LocalOnly extends CachePolicy
+
+  /** Only pick local files, possibly from the cache. Don't return changing artifacts (whose last check is) older than TTL */
+  case object LocalOnlyIfValid extends CachePolicy
+
+  /**
+   * Only pick local files. If one of these local files corresponds to a changing artifact, check
+   * for updates, and download these if needed.
+   *
+   * If no local file is found, *don't* try download it. Updates are only checked for files already
+   * in cache.
+   *
+   * Follows the TTL parameter (assumes no update is needed if the last one is recent enough).
+   */
+  case object LocalUpdateChanging extends CachePolicy
+
+  /**
+   * Only pick local files, check if any update is available for them, and download these if needed.
+   *
+   * If no local file is found, *don't* try download it. Updates are only checked for files already
+   * in cache.
+   *
+   * Follows the TTL parameter (assumes no update is needed if the last one is recent enough).
+   *
+   * Unlike `LocalUpdateChanging`, all found local files are checked for updates, not just the
+   * changing ones.
+   */
+  case object LocalUpdate extends CachePolicy
+
+  /**
+   * Pick local files, and download the missing ones.
+   *
+   * For changing ones, check for updates, and download those if any.
+   *
+   * Follows the TTL parameter (assumes no update is needed if the last one is recent enough).
+   */
+  case object UpdateChanging extends CachePolicy
+
+  /**
+   * Pick local files, download the missing ones, check for updates and download those if any.
+   *
+   * Follows the TTL parameter (assumes no update is needed if the last one is recent enough).
+   *
+   * Unlike `UpdateChanging`, all found local files are checked for updates, not just the changing
+   * ones.
+   */
+  case object Update extends CachePolicy
+
+  /**
+   * Pick local files, download the missing ones.
+   *
+   * No updates are checked for files already downloaded.
+   */
+  case object FetchMissing extends CachePolicy
+
+  /**
+   * (Re-)download all files.
+   *
+   * Erases files already in cache.
+   */
+  case object ForceDownload extends CachePolicy
+}

--- a/modules/lm-coursier/src/main/scala/lmcoursier/definitions/FromCoursier.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/definitions/FromCoursier.scala
@@ -1,0 +1,18 @@
+package lmcoursier.definitions
+
+// TODO Make private[lmcoursier]
+// private[coursier]
+object FromCoursier {
+
+  def cachePolicy(r: coursier.cache.CachePolicy): CachePolicy =
+    r match {
+      case coursier.cache.CachePolicy.LocalOnly => CachePolicy.LocalOnly
+      case coursier.cache.CachePolicy.LocalOnlyIfValid => CachePolicy.LocalOnlyIfValid
+      case coursier.cache.CachePolicy.LocalUpdateChanging => CachePolicy.LocalUpdateChanging
+      case coursier.cache.CachePolicy.LocalUpdate => CachePolicy.LocalUpdate
+      case coursier.cache.CachePolicy.UpdateChanging => CachePolicy.UpdateChanging
+      case coursier.cache.CachePolicy.Update => CachePolicy.Update
+      case coursier.cache.CachePolicy.FetchMissing => CachePolicy.FetchMissing
+      case coursier.cache.CachePolicy.ForceDownload => CachePolicy.ForceDownload
+    }
+}

--- a/modules/lm-coursier/src/main/scala/lmcoursier/definitions/ToCoursier.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/definitions/ToCoursier.scala
@@ -175,4 +175,16 @@ object ToCoursier {
       },
       // ignoreIfForcedVersion = strict.ignoreIfForcedVersion // should be around once the coursier version is bumped
     )
+
+  def cachePolicy(r: CachePolicy): coursier.cache.CachePolicy =
+    r match {
+      case CachePolicy.LocalOnly => coursier.cache.CachePolicy.LocalOnly
+      case CachePolicy.LocalOnlyIfValid => coursier.cache.CachePolicy.LocalOnlyIfValid
+      case CachePolicy.LocalUpdateChanging => coursier.cache.CachePolicy.LocalUpdateChanging
+      case CachePolicy.LocalUpdate => coursier.cache.CachePolicy.LocalUpdate
+      case CachePolicy.UpdateChanging => coursier.cache.CachePolicy.UpdateChanging
+      case CachePolicy.Update => coursier.cache.CachePolicy.Update
+      case CachePolicy.FetchMissing => coursier.cache.CachePolicy.FetchMissing
+      case CachePolicy.ForceDownload => coursier.cache.CachePolicy.ForceDownload
+    }
 }


### PR DESCRIPTION
With advice from @alexarchambault and @eed3si9n, this PR exposes a couple additional properties into the `CoursierConfiguration` data object available to SBT.

The following properties are exposed, with defaults set from `CoursierDefaults`:
  - ttl (24 hours, overridable by properties or environment varialbe)
  - verbosityLevel (0)
  - checksums ("SHA-1" or none)
  - cache policies (`LocalUpdateChanging :: LocalOnly :: Update :: Nil`, overridable with coursier.mode or COURSIER_MODE)

Performing this exposition should enable a project to perform programmatic overrides, without requiring to alter the environment outside SBT's invocation.