### PR TITLE
Merge transitive and direct reverse dependencies, close sbt/stb#5484

### DIFF
--- a/modules/lm-coursier/src/main/scala/lmcoursier/internal/SbtUpdateReport.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/internal/SbtUpdateReport.scala
@@ -213,15 +213,21 @@ private[internal] object SbtUpdateReport {
       )
       .toMap
 
-    val reverseDependencies = res.reverseDependencies
-      .toVector
-      .map { case (k, v) =>
-        clean(k) -> v.map(clean)
-      }
-      .groupBy(_._1)
-      .mapValues(_.flatMap(_._2))
-      .toVector
-      .toMap ++ directReverseDependencies
+    val reverseDependencies = {
+      val transitiveReverseDependencies = res.reverseDependencies
+        .toVector
+        .map { case (k, v) =>
+          clean(k) -> v.map(clean)
+        }
+        .groupBy(_._1)
+        .mapValues(_.flatMap(_._2))
+
+      (transitiveReverseDependencies.toVector ++ directReverseDependencies.toVector)
+        .groupBy(_._1)
+        .mapValues(_.flatMap(_._2).toVector)
+        .toVector
+        .toMap
+    }
 
     groupedDepArtifacts.toVector.map {
       case (dep, artifacts) =>


### PR DESCRIPTION
Motivation:

Direct reverse dependencies Map is added into the transitive reverse dependencies Map, so any dependency existing in both Maps loses transitive callers.

This behavior is not consistent with the ivy based lm and is not desirable: the goal is to have the complete callers tree.

Modification:

Merge the 2 maps instead of adding and lose values for conflicting keys.

Result:

Transitive callers are not lost when dependency is also pulled directly.