### PR TITLE
header based authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,3 @@ target/
 # Intellij
 .idea/
 
-#vscode
-.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,11 @@
 target/
+
+# Metals / bloop
+.metals/
+.bloop/
+
+# Intellij
+.idea/
+
+#vscode
+.vscode/

--- a/modules/lm-coursier/src/main/scala/lmcoursier/CoursierConfiguration.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/CoursierConfiguration.scala
@@ -76,7 +76,7 @@ import scala.concurrent.duration.Duration
   def withTtl(ttl: Duration): CoursierConfiguration =
     withTtl(Some(ttl))
   def addRepositoryAuthentication(repositoryId: String, authentication: Authentication): CoursierConfiguration =
-    withAuthenticationByRepositoryId(authenticationByRepositoryId +: (repositoryId, authentication))
+    withAuthenticationByRepositoryId(authenticationByRepositoryId :+ (repositoryId, authentication))
 }
 
 object CoursierConfiguration {

--- a/modules/lm-coursier/src/main/scala/lmcoursier/CoursierConfiguration.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/CoursierConfiguration.scala
@@ -75,6 +75,8 @@ import scala.concurrent.duration.Duration
     withStrict(Some(strict))
   def withTtl(ttl: Duration): CoursierConfiguration =
     withTtl(Some(ttl))
+  def addRepositoryAuthentication(repositoryId: String, authentication: Authentication): CoursierConfiguration =
+    withAuthenticationByRepositoryId(authenticationByRepositoryId +: (repositoryId, authentication))
 }
 
 object CoursierConfiguration {

--- a/modules/lm-coursier/src/main/scala/lmcoursier/definitions/Authentication.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/definitions/Authentication.scala
@@ -6,7 +6,8 @@ import dataclass.data
   user: String,
   password: String,
   optional: Boolean = false,
-  realmOpt: Option[String] = None
+  realmOpt: Option[String] = None,
+  headersOpt: Option[Seq[(String,String)]] = None
 ) {
   override def toString(): String =
     withPassword("****")

--- a/modules/lm-coursier/src/main/scala/lmcoursier/definitions/Authentication.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/definitions/Authentication.scala
@@ -20,5 +20,5 @@ import dataclass._
 object Authentication {
 
   def apply(headers: Seq[(String, String)]): Authentication =
-    Authentication("", "", optional = false, None, httpHeaders)
+    Authentication("", "", optional = false, None, headers)
 }

--- a/modules/lm-coursier/src/main/scala/lmcoursier/definitions/Authentication.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/definitions/Authentication.scala
@@ -1,12 +1,13 @@
 package lmcoursier.definitions
 
-import dataclass.data
+import dataclass._
 
 @data class Authentication(
   user: String,
   password: String,
   optional: Boolean = false,
   realmOpt: Option[String] = None,
+  @since
   headersOpt: Option[Seq[(String,String)]] = None
 ) {
   override def toString(): String =

--- a/modules/lm-coursier/src/main/scala/lmcoursier/definitions/Authentication.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/definitions/Authentication.scala
@@ -12,7 +12,13 @@ import dataclass._
 ) {
   override def toString(): String =
     withPassword("****")
-    .withHeaders(headers.map((_._1,"****")))
+    .withHeaders(headers.map(x=>(x._1,"****")))
       .productIterator
       .mkString("Authentication(", ", ", ")")
+}
+
+object Authentication {
+
+  def apply(headers: Seq[(String, String)]): Authentication =
+    Authentication("", "", optional = false, None, httpHeaders)
 }

--- a/modules/lm-coursier/src/main/scala/lmcoursier/definitions/Authentication.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/definitions/Authentication.scala
@@ -8,10 +8,11 @@ import dataclass._
   optional: Boolean = false,
   realmOpt: Option[String] = None,
   @since
-  headersOpt: Option[Seq[(String,String)]] = None
+  headers: Seq[(String,String)] = Nil
 ) {
   override def toString(): String =
     withPassword("****")
+    .withHeaders(headers.map((_._1,"****")))
       .productIterator
       .mkString("Authentication(", ", ", ")")
 }

--- a/modules/lm-coursier/src/main/scala/lmcoursier/definitions/ToCoursier.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/definitions/ToCoursier.scala
@@ -23,12 +23,12 @@ object ToCoursier {
       coursier.core.Classifier(publication.classifier.value)
     )
 
-  def authentication(authentication: Authentication): coursier.core.Authentication = authentication.headersOpt match {
-    case None =>
+  def authentication(authentication: Authentication): coursier.core.Authentication = authentication.headers match {
+    case Nil =>
     coursier.core.Authentication(authentication.user, authentication.password)
       .withOptional(authentication.optional)
       .withRealmOpt(authentication.realmOpt)
-    case Some(headers) => coursier.core.Authentication(headers)
+    case headers => coursier.core.Authentication(headers)
       .withOptional(authentication.optional)
       .withRealmOpt(authentication.realmOpt)
       .withPassOnRedirect(true)

--- a/modules/lm-coursier/src/main/scala/lmcoursier/definitions/ToCoursier.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/definitions/ToCoursier.scala
@@ -23,10 +23,16 @@ object ToCoursier {
       coursier.core.Classifier(publication.classifier.value)
     )
 
-  def authentication(authentication: Authentication): coursier.core.Authentication =
+  def authentication(authentication: Authentication): coursier.core.Authentication = authentication.headersOpt match {
+    case None =>
     coursier.core.Authentication(authentication.user, authentication.password)
       .withOptional(authentication.optional)
       .withRealmOpt(authentication.realmOpt)
+    case Some(headers) => coursier.core.Authentication(headers)
+      .withOptional(authentication.optional)
+      .withRealmOpt(authentication.realmOpt)
+      .withPassOnRedirect(true)
+  }  
 
   def module(module: Module): coursier.core.Module =
     coursier.core.Module(

--- a/modules/sbt-lm-coursier/src/main/scala/coursier/sbtlmcoursier/LmCoursierPlugin.scala
+++ b/modules/sbt-lm-coursier/src/main/scala/coursier/sbtlmcoursier/LmCoursierPlugin.scala
@@ -111,7 +111,7 @@ object LmCoursierPlugin extends AutoPlugin {
 
         val authenticationByRepositoryId = coursierCredentials.value.mapValues { c =>
           val a = c.authentication
-          Authentication(a.user, a.password, a.optional, a.realmOpt,a.headersOpt)
+          Authentication(a.user, a.password, a.optional, a.realmOpt)
         }
         val credentials = credentialsTask.value
         val strict = strictTask.value

--- a/modules/sbt-lm-coursier/src/main/scala/coursier/sbtlmcoursier/LmCoursierPlugin.scala
+++ b/modules/sbt-lm-coursier/src/main/scala/coursier/sbtlmcoursier/LmCoursierPlugin.scala
@@ -111,7 +111,7 @@ object LmCoursierPlugin extends AutoPlugin {
 
         val authenticationByRepositoryId = coursierCredentials.value.mapValues { c =>
           val a = c.authentication
-          Authentication(a.user, a.password, a.optional, a.realmOpt)
+          Authentication(a.user, a.password, a.optional, a.realmOpt,a.headersOpt)
         }
         val credentials = credentialsTask.value
         val strict = strictTask.value


### PR DESCRIPTION
adding ability to pass headers through to coursier when authenticating with repo
related: https://github.com/sbt/sbt/issues/5473
resolves: https://github.com/coursier/coursier/issues/1203

```scala
resolvers +=
  "gitlab" at "https://gitlab.com/api/v4/projects/1234567/packages/maven"

csrConfiguration ~=
(_.withAuthenticationByRepositoryId(Vector(("gitlab",Authentication("","",false,None,Some(Seq(("Private-Token","xxxx"))))))))
updateClassifiers / csrConfiguration ~= (_.withAuthenticationByRepositoryId(Vector(("gitlab",Authentication("","",false,None,Some(Seq(("Private-Token","xxxx"))))))))
```

if merged might be useful to add a task to sbt to add these a bit more elegantly