### PR TITLE
Fix Provided configuration handling, take 2

### DIFF
--- a/modules/lm-coursier/src/main/scala/lmcoursier/CoursierConfiguration.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/CoursierConfiguration.scala
@@ -53,7 +53,9 @@ import scala.concurrent.duration.Duration
   @since
   missingOk: Boolean = false,
   @since
-  sbtClassifiers: Boolean = false
+  sbtClassifiers: Boolean = false,
+  @since
+  providedInCompile: Boolean = false // unused, kept for binary compatibility
 ) {
 
   def withLog(log: Logger): CoursierConfiguration =

--- a/modules/lm-coursier/src/main/scala/lmcoursier/CoursierConfiguration.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/CoursierConfiguration.scala
@@ -53,9 +53,7 @@ import scala.concurrent.duration.Duration
   @since
   missingOk: Boolean = false,
   @since
-  sbtClassifiers: Boolean = false,
-  @since
-  providedInCompile: Boolean = true
+  sbtClassifiers: Boolean = false
 ) {
 
   def withLog(log: Logger): CoursierConfiguration =

--- a/modules/lm-coursier/src/main/scala/lmcoursier/CoursierDependencyResolution.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/CoursierDependencyResolution.scala
@@ -146,15 +146,10 @@ class CoursierDependencyResolution(conf: CoursierConfiguration) extends Dependen
       }
       .toSet
 
-    val providedOpt = orderedConfigs.collectFirst {
-      case (c, _) if conf.providedInCompile && c.value.equalsIgnoreCase("provided") => c
-    }
-
     val resolutionParams = ResolutionParams(
       dependencies = dependencies,
       fallbackDependencies = conf.fallbackDependencies,
-      orderedConfigs = providedOpt.fold(orderedConfigs)(provided => orderedConfigs.filter(_._1 != provided)),
-      subConfigs = providedOpt.map(_ -> coursier.core.Configuration.compile).toSeq,
+      orderedConfigs = orderedConfigs,
       autoScalaLibOpt = if (conf.autoScalaLibrary) Some((so, sv)) else None,
       mainRepositories = mainRepositories,
       parentProjectCache = Map.empty,

--- a/modules/lm-coursier/src/main/scala/lmcoursier/internal/ResolutionParams.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/internal/ResolutionParams.scala
@@ -17,7 +17,6 @@ final case class ResolutionParams(
   dependencies: Seq[(Configuration, Dependency)],
   fallbackDependencies: Seq[FallbackDependency],
   orderedConfigs: Seq[(Configuration, Seq[Configuration])],
-  subConfigs: Seq[(Configuration, Configuration)],
   autoScalaLibOpt: Option[(Organization, String)],
   mainRepositories: Seq[Repository],
   parentProjectCache: ProjectCache,
@@ -35,18 +34,12 @@ final case class ResolutionParams(
 
   lazy val allConfigExtends: Map[Configuration, Set[Configuration]] = {
     val map = new mutable.HashMap[Configuration, Set[Configuration]]
-    val subConfigMap = subConfigs
-      .map { case (config, parent) => parent -> config }
-      .groupBy(_._1)
-      .mapValues(_.map(_._2))
-      .toMap
     for ((config, extends0) <- orderedConfigs) {
       val allExtends = extends0
         .iterator
         // the else of the getOrElse shouldn't be hit (because of the ordering of the configurations)
         .foldLeft(Set(config))((acc, ext) => acc ++ map.getOrElse(ext, Set(ext)))
-      val viaSubConfig = subConfigMap.getOrElse(config, Nil)
-      map += config -> (allExtends ++ viaSubConfig)
+      map += config -> allExtends
     }
     map.toMap
   }

--- a/modules/lm-coursier/src/main/scala/lmcoursier/internal/ResolutionRun.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/internal/ResolutionRun.scala
@@ -158,32 +158,7 @@ object ResolutionRun {
                 ()
               }
           }
-          val withSubResolutions = params.subConfigs.foldLeft(either) {
-            case (acc, (config, parent)) =>
-              for {
-                _ <- acc
-                initResOpt = map.get(parent)
-                allExtends = params.allConfigExtends.getOrElse(config, Set.empty)
-                res <- {
-                  initResOpt match {
-                    case None =>
-                      val allExtendsWithParent = allExtends ++
-                        params.allConfigExtends.getOrElse(parent, Set.empty)
-                      resolution(params, verbosityLevel, log, allExtendsWithParent, None)
-                    case Some(initRes) =>
-                      val deps = params.dependencies.collect {
-                        case (config, dep) if allExtends(config) =>
-                          dep
-                      }
-                      Right(initRes.subset(deps))
-                  }
-                }
-              } yield {
-                map += config -> res
-                ()
-              }
-          }
-          withSubResolutions.map(_ => map.toMap)
+          either.map(_ => map.toMap)
         }
       for (res <- resOrError)
         SbtCoursierCache.default.putResolution(params.resolutionKey, res)

--- a/modules/sbt-coursier/src/main/scala/coursier/sbtcoursier/ResolutionTasks.scala
+++ b/modules/sbt-coursier/src/main/scala/coursier/sbtcoursier/ResolutionTasks.scala
@@ -138,16 +138,11 @@ object ResolutionTasks {
           )
         }
 
-      val providedOpt = orderedConfigs.collectFirst {
-        case (c, _) if c.value.equalsIgnoreCase("provided") => c
-      }
-
       val resOrError = ResolutionRun.resolutions(
         ResolutionParams(
           dependencies = currentProject.dependencies,
           fallbackDependencies = fallbackDependencies,
           orderedConfigs = orderedConfigs,
-          subConfigs = providedOpt.map(_ -> coursier.core.Configuration.compile).toSeq,
           autoScalaLibOpt = if (autoScalaLib) Some((so, sv)) else None,
           mainRepositories = mainRepositories,
           parentProjectCache = parentProjectCache,

--- a/modules/sbt-coursier/src/sbt-test/shared-2/provided/build.sbt
+++ b/modules/sbt-coursier/src/sbt-test/shared-2/provided/build.sbt
@@ -1,6 +1,9 @@
+import sbt.librarymanagement.Configurations.{ CompileInternal, RuntimeInternal, TestInternal }
+
 libraryDependencies ++= Seq(
   "com.github.alexarchambault" %% "argonaut-shapeless_6.2" % "1.2.0-M5",
-  "com.chuusai" %% "shapeless" % "2.3.3" % Provided
+  "com.chuusai" %% "shapeless" % "2.3.3" % Provided,
+  "javax.servlet" % "servlet-api" % "2.5" % Provided
 )
 scalaVersion := "2.12.11"
 
@@ -10,17 +13,17 @@ check := {
 
   val updateReport = update.value
 
-  def checkVersions(config: Configuration): Unit = {
+  def configReport(config: Configuration) = updateReport
+    .configuration(config)
+    .getOrElse {
+      throw new Exception(
+        s"$config configuration not found in update report"
+      )
+    }
 
-    val configReport = updateReport
-      .configuration(Compile)
-      .getOrElse {
-        throw new Exception(
-          s"$config configuration not found in update report"
-        )
-      }
+  def checkShapelessVersions(config: Configuration, expected: Option[String]): Unit = {
 
-    val shapelessVersions = configReport
+    val shapelessVersions = configReport(config)
       .modules
       .map(_.module)
       .collect {
@@ -29,13 +32,42 @@ check := {
       }
       .toSet
 
-    val expectedShapelessVersions = Set("2.3.3")
     assert(
-      shapelessVersions == expectedShapelessVersions,
-      s"Expected shapeless versions $expectedShapelessVersions, got $shapelessVersions"
+      shapelessVersions == expected.toSet,
+      s"Expected shapeless versions ${expected.toSet} in $config, got $shapelessVersions"
     )
   }
 
-  checkVersions(Compile)
-  checkVersions(Provided)
+  def checkServletVersions(config: Configuration, expected: Option[String]): Unit = {
+
+    val servletVersions = configReport(config)
+      .modules
+      .map(_.module)
+      .collect {
+        case m if m.organization == "javax.servlet" && m.name.startsWith("servlet-api") =>
+          m.revision
+      }
+      .toSet
+
+    assert(
+      servletVersions == expected.toSet,
+      s"Expected servlet-api versions ${expected.toSet} in $config, got $servletVersions"
+    )
+  }
+
+  checkShapelessVersions(Compile, Some("2.3.2"))
+  checkShapelessVersions(CompileInternal, Some("2.3.3"))
+  checkShapelessVersions(Test, Some("2.3.2"))
+  checkShapelessVersions(TestInternal, Some("2.3.3"))
+  checkShapelessVersions(Provided, Some("2.3.3"))
+  checkShapelessVersions(Runtime, Some("2.3.2"))
+  checkShapelessVersions(RuntimeInternal, Some("2.3.2"))
+
+  checkServletVersions(Compile, None)
+  checkServletVersions(CompileInternal, Some("2.5"))
+  checkServletVersions(Test, None)
+  checkServletVersions(TestInternal, Some("2.5"))
+  checkServletVersions(Provided, Some("2.5"))
+  checkServletVersions(Runtime, None)
+  checkServletVersions(RuntimeInternal, None)
 }


### PR DESCRIPTION
Fixes https://github.com/coursier/coursier/issues/1813
Ref https://github.com/sbt/sbt/pull/5575

This simply reverts #239. `Provided` configuration is included into `CompileInternal`, but not `RuntimeInternal` so we can just let them get resolved, and `Provided`-scoped dependencies should be handled.