### PR TITLE
Don't lock threads when user has specified COURSIER_PROGRESS=disable

### DIFF
--- a/modules/lm-coursier/src/main/scala/lmcoursier/internal/Lock.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/internal/Lock.scala
@@ -1,10 +1,10 @@
 package lmcoursier.internal
 
 private[lmcoursier] object Lock {
+  private val lock = new Object
 
-  // Wrap blocks downloading stuff (resolution / artifact downloads) in lock.synchronized.
-  // Downloads are already parallel, no need to parallelize further, and this results in
-  // a clearer output.
-  val lock = new Object
-
+  /* Progress bars require us to only work on one module at the time. Without those we can go faster */
+  def maybeSynchronized[T](needsLock: Boolean)(f: => T): T =
+    if (needsLock) lock.synchronized(f)
+    else f
 }

--- a/modules/lm-coursier/src/main/scala/lmcoursier/internal/ResolutionRun.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/internal/ResolutionRun.scala
@@ -137,10 +137,8 @@ object ResolutionRun {
     }
 
     SbtCoursierCache.default.resolutionOpt(params.resolutionKey).map(Right(_)).getOrElse {
-      // Let's update only one module at once, for a better output.
-      // Downloads are already parallel, no need to parallelize further, anyway.
       val resOrError =
-        Lock.lock.synchronized {
+        Lock.maybeSynchronized(needsLock = params.loggerOpt.nonEmpty || !RefreshLogger.defaultFallbackMode) {
           var map = new mutable.HashMap[Configuration, Resolution]
           val either = params.orderedConfigs.foldLeft[Either[coursier.error.ResolutionError, Unit]](Right(())) {
             case (acc, (config, extends0)) =>

--- a/modules/lm-coursier/src/main/scala/lmcoursier/internal/UpdateRun.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/internal/UpdateRun.scala
@@ -1,5 +1,6 @@
 package lmcoursier.internal
 
+import coursier.cache.loggers.RefreshLogger
 import coursier.core.Resolution.ModuleVersion
 import coursier.core._
 import coursier.util.Print
@@ -55,8 +56,7 @@ object UpdateRun {
     params: UpdateParams,
     verbosityLevel: Int,
     log: Logger
-  ): UpdateReport = Lock.lock.synchronized {
-
+  ): UpdateReport = Lock.maybeSynchronized(needsLock = !RefreshLogger.defaultFallbackMode) {
     val depsByConfig = grouped(params.dependencies)
 
     if (verbosityLevel >= 2) {


### PR DESCRIPTION
Hey there @alexarchambault . Sorry, this has been long in the making, and it's too bad I couldn't follow up in time for sbt 1.4.0 and coursier 2 (congrats on that by the way!)

So ok, this again is about https://github.com/coursier/coursier/issues/1720 . 

I still want to find a best of both worlds approach here, but let's fix what we have first. With this change in place, expert users can add an environment variable to their shell to get faster builds, and typically on CI you get it for free.

The lock we have talked about before is still taken in two of three places with disabled progress bars, and as such things are still slow on larger projects.

The effects should be as dramatic as I've mentioned before. on `sbt-multi-module-sample` I'm seeing up to three times faster cold `update`, and on a work project I'm seing up to twice as fast.
