### PR TITLE
Do resolutions within a module in parallel

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,12 @@ lazy val `lm-coursier` = project
         else lm2_13Version
       },
       "org.scalatest" %% "scalatest" % "3.2.11" % Test
-    ),
+    ) ++ {
+      if (scalaBinaryVersion.value == "2.12")
+        Seq()
+      else
+        Seq("org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4")
+    },
     Test / test := {
       (publishLocal in customProtocolForTest212).value
       (publishLocal in customProtocolForTest213).value

--- a/modules/lm-coursier/src/main/scala/lmcoursier/internal/CompatParColls.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/internal/CompatParColls.scala
@@ -1,0 +1,20 @@
+package lmcoursier.internal
+
+// This is required for jscala 2.12/2.13 compatibility for parallel collections
+// (see https://github.com/scala/scala-parallel-collections/issues/22)
+private[internal] object CompatParColls {
+  val Converters = {
+    import Compat._
+
+    {
+      import scala.collection.parallel._
+
+      CollectionConverters
+    }
+  }
+
+  object Compat {
+    object CollectionConverters
+  }
+}
+

--- a/modules/lm-coursier/src/main/scala/lmcoursier/internal/SbtUpdateReport.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/internal/SbtUpdateReport.scala
@@ -12,6 +12,7 @@ import coursier.maven.MavenAttributes
 import coursier.util.Artifact
 import sbt.librarymanagement.{Artifact => _, Configuration => _, _}
 import sbt.util.Logger
+import CompatParColls.Converters._
 
 private[internal] object SbtUpdateReport {
 
@@ -303,7 +304,7 @@ private[internal] object SbtUpdateReport {
     classLoaders: Seq[ClassLoader],
   ): UpdateReport = {
 
-    val configReports = resolutions.map {
+    val configReports = resolutions.par.map {
       case (config, subRes) =>
 
         val reports = moduleReports(


### PR DESCRIPTION
Profiling showed conflict resolution to be a performance hotspot. Cpu utilization is a about 2 cores on my machine, after parallelizing the toplevel resolution loop utilization went to about 4 cores for my local workload.

With this change i measured a performance improvement from 50 seconds on `sbt update` to 30 seconds.