### PR TITLE
chore(deps): bump scala-xml to 2.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -189,7 +189,7 @@ lazy val `lm-coursier-shaded` = project
       "io.get-coursier.jniutils" % "windows-jni-utils-lmcoursier" % jniUtilsVersion,
       "net.hamnaberg" %% "dataclass-annotation" % dataclassScalafixV % Provided,
       "org.scala-lang.modules" %% "scala-collection-compat" % "2.8.1",
-      "org.scala-lang.modules" %% "scala-xml" % "1.3.0", // depending on that one so that it doesn't get shaded
+      "org.scala-lang.modules" %% "scala-xml" % "2.1.0", // depending on that one so that it doesn't get shaded
       "org.slf4j" % "slf4j-api" % "2.0.3", // depending on that one so that it doesn't get shaded either
       lmIvy.value,
       "org.scalatest" %% "scalatest" % "3.2.14" % Test


### PR DESCRIPTION
Same reason that I had for https://github.com/coursier/coursier/pull/2548 but since sbt 1.7.3 was released a bunch of people will see the following:

```
03:31:06  [info] loading global plugins from /root/.sbt/1.0/plugins
03:31:10  [error] java.lang.RuntimeException: found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
03:31:10  [error]
03:31:10  [error] * org.scala-lang.modules:scala-xml_2.12:2.1.0 (early-semver) is selected over {1.3.0, 1.2.0, 1.0.6}
03:31:10  [error]     +- org.scala-lang:scala-compiler:2.12.17              (depends on 2.1.0)
03:31:10  [error]     +- org.scala-sbt:testing_2.12:1.7.3                   (depends on 1.3.0)
03:31:10  [error]     +- org.scala-sbt:sbinary_2.12:0.5.1                   (depends on 1.0.6)
03:31:10  [error]     +- org.scala-sbt:main_2.12:1.7.3                      (depends on 1.3.0)
03:31:10  [error]     +- org.scala-sbt:librarymanagement-core_2.12:1.7.1    (depends on 1.2.0)
03:31:10  [error]     +- io.get-coursier:lm-coursier-shaded_2.12:2.0.12     (depends on 1.3.0)
```
Since there is a mismatch of scala-xml all over the place. Since Scala has bumped I think it's appropriate the everyone else bumps as well. sbt has also merged in this change for the 1.8.x series.

Relates to https://github.com/sbt/sbt/issues/6997.