### PR TITLE
Revert "Update slf4j-api to 2.0.3"

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,3 @@
+updates.pin  = [
+  { groupId = "org.slf4j", artifactId="slf4j-api", version = "1." }
+]

--- a/build.sbt
+++ b/build.sbt
@@ -192,7 +192,7 @@ lazy val `lm-coursier-shaded` = project
       "net.hamnaberg" %% "dataclass-annotation" % dataclassScalafixV % Provided,
       "org.scala-lang.modules" %% "scala-collection-compat" % "2.9.0",
       "org.scala-lang.modules" %% "scala-xml" % "2.1.0", // depending on that one so that it doesn't get shaded
-      "org.slf4j" % "slf4j-api" % "2.0.6", // depending on that one so that it doesn't get shaded either
+      "org.slf4j" % "slf4j-api" % "1.7.36", // depending on that one so that it doesn't get shaded either
       lmIvy.value,
       "org.scalatest" %% "scalatest" % "3.2.14" % Test
     )


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/7062

This reverts commit 8f594cf0f78060019b5a75ee083a8bd35872ca6c / https://github.com/coursier/sbt-coursier/pull/422

I don't think there's any reason for lm-coursier-shaded to bring in slf4j-api 2.x series, given that underlying Coursier is still on slf4j 1.x.