### PR TITLE
fix condition in Resolvers.mavenCompatibleBaseOpt (use artifactPatterns instead of ivyPatterns)

### DIFF
--- a/modules/lm-coursier/src/main/scala/lmcoursier/internal/Resolvers.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/internal/Resolvers.scala
@@ -17,8 +17,12 @@ object Resolvers {
 
   private def mavenCompatibleBaseOpt(patterns: Patterns): Option[String] =
     if (patterns.isMavenCompatible) {
-      val baseIvyPattern = patterns.ivyPatterns.head.takeWhile(c => c != '[' && c != '(')
-      val baseArtifactPattern = patterns.ivyPatterns.head.takeWhile(c => c != '[' && c != '(')
+      //input  : /Users/user/custom/repo/[organisation]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]
+      //output : /Users/user/custom/repo/
+      def basePattern(pattern: String): String = pattern.takeWhile(c => c != '[' && c != '(')
+
+      val baseIvyPattern = basePattern(patterns.ivyPatterns.head)
+      val baseArtifactPattern = basePattern(patterns.artifactPatterns.head)
 
       if (baseIvyPattern == baseArtifactPattern)
         Some(baseIvyPattern)


### PR DESCRIPTION


Before the change `Resolvers.mavenCompatibleBaseOpt` always returned `Some `value because `baseIvyPattern == baseArtifactPattern` always was `true``