### PR TITLE
Use non-empty project name for logging

### DIFF
--- a/modules/lm-coursier/src/main/scala/lmcoursier/CoursierDependencyResolution.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/CoursierDependencyResolution.scala
@@ -168,7 +168,7 @@ class CoursierDependencyResolution(
     val cache = conf.cache.getOrElse(CacheDefaults.location)
     val cachePolicies = conf.cachePolicies.map(ToCoursier.cachePolicy)
     val checksums = conf.checksums
-    val projectName = "" // used for logging only…
+    val projectName = module0.module.name
 
     val ivyProperties = ResolutionParams.defaultIvyProperties(conf.ivyHome)
 


### PR DESCRIPTION
I've been seeing these for a long time:

```
[info] Resolved  dependencies
[info] Fetching artifacts of 
[info] Fetched artifacts of 
[info] Fetching artifacts of 
[info] Fetched artifacts of
```

Clearly something was wrong. Turns out, the string being interpolated into all these logs has been empty all along!

```scala
val projectName = "" // used for logging only…
```

This PR sets the value to the best thing I found in scope. Let me know if there should be a test.