### PR TITLE
Add a `sameVersions` paramter to CoursierConfiguration

### DIFF
--- a/modules/definitions/src/main/scala/lmcoursier/CoursierConfiguration.scala
+++ b/modules/definitions/src/main/scala/lmcoursier/CoursierConfiguration.scala
@@ -1,12 +1,12 @@
 package lmcoursier
 
 import java.io.File
-
-import dataclass.{ data, since }
+import dataclass.{data, since}
 import coursier.cache.CacheDefaults
+import coursier.params.rule.{Rule, RuleResolution}
 import lmcoursier.credentials.Credentials
 import lmcoursier.definitions.{Authentication, CacheLogger, CachePolicy, FromCoursier, Module, ModuleMatchers, Project, Reconciliation, Strict}
-import sbt.librarymanagement.{Resolver, UpdateConfiguration, ModuleID, CrossVersion, ModuleInfo, ModuleDescriptorConfiguration}
+import sbt.librarymanagement.{CrossVersion, InclExclRule, ModuleDescriptorConfiguration, ModuleID, ModuleInfo, Resolver, UpdateConfiguration}
 import xsbti.Logger
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
@@ -60,4 +60,5 @@ import java.net.URLClassLoader
   @since
   protocolHandlerDependencies: Seq[ModuleID] = Vector.empty,
   retry: Option[(FiniteDuration, Int)] = None,
+  sameVersions: Seq[Set[InclExclRule]] = Nil,
 )

--- a/modules/lm-coursier/src/main/scala/lmcoursier/CoursierDependencyResolution.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/CoursierDependencyResolution.scala
@@ -251,7 +251,8 @@ class CoursierDependencyResolution(
         .withForceVersion(conf.forceVersions.map { case (k, v) => (ToCoursier.module(k), v) }.toMap)
         .withTypelevel(typelevel)
         .withReconciliation(ToCoursier.reconciliation(conf.reconciliation))
-        .withExclusions(excludeDependencies),
+        .withExclusions(excludeDependencies)
+        .withRules(ToCoursier.sameVersions(conf.sameVersions)),
       strictOpt = conf.strict.map(ToCoursier.strict),
       missingOk = conf.missingOk,
       retry = conf.retry.getOrElse(ResolutionParams.defaultRetry),

--- a/modules/lm-coursier/src/main/scala/lmcoursier/internal/ResolutionRun.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/internal/ResolutionRun.scala
@@ -39,7 +39,7 @@ object ResolutionRun {
         params.mainRepositories ++
         params.fallbackDependenciesRepositories
 
-    val rules = params.strictOpt.map(s => Seq((s, RuleResolution.Fail))).getOrElse(Nil)
+    val rules = params.params.rules ++ params.strictOpt.map(s => Seq((s, RuleResolution.Fail))).getOrElse(Nil)
 
     val printOptionalMessage = verbosityLevel >= 0 && verbosityLevel <= 1
 
@@ -182,7 +182,7 @@ object ResolutionRun {
     SbtCoursierCache.default.resolutionOpt(params.resolutionKey).map(Right(_)).getOrElse {
       val resOrError =
         Lock.maybeSynchronized(needsLock = params.loggerOpt.nonEmpty || !RefreshLogger.defaultFallbackMode) {
-          var map = new mutable.HashMap[Configuration, Resolution]
+          val map = new mutable.HashMap[Configuration, Resolution]
           val either = params.orderedConfigs.foldLeft[Either[coursier.error.ResolutionError, Unit]](Right(())) {
             case (acc, (config, extends0)) =>
               for {

--- a/modules/lm-coursier/src/main/scala/lmcoursier/syntax/package.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/syntax/package.scala
@@ -74,7 +74,8 @@ package object syntax {
         sbtClassifiers = false,
         providedInCompile = false,
         protocolHandlerDependencies = Vector.empty,
-        retry = None
+        retry = None,
+        sameVersions = Nil,
       )
   }
 


### PR DESCRIPTION
Expose coursier's `SameVersion` rule to allow pinning libraries to the same version.

This is needed for [SIP-51, unfreeze the Scala library](https://docs.scala-lang.org/sips/drop-stdlib-forwards-bin-compat.html) / https://github.com/sbt/sbt/pull/7480.