### PR TITLE
Resolve license inheritence in update report

### DIFF
--- a/modules/lm-coursier/src/test/scala/lmcoursier/ResolutionSpec.scala
+++ b/modules/lm-coursier/src/test/scala/lmcoursier/ResolutionSpec.scala
@@ -235,4 +235,17 @@ final class ResolutionSpec extends AnyPropSpec with Matchers {
 
     resolution should be('right)
   }
+
+  property("resolve licenses from parent poms") {
+    val dependencies =
+      Vector(("org.apache.commons" % "commons-compress" % "1.26.2"))
+    val coursierModule = module(lmEngine, stubModule, dependencies, Some("2.12.4"))
+    val resolution =
+      lmEngine.update(coursierModule, UpdateConfiguration(), UnresolvedWarningConfiguration(), log)
+
+    resolution should be('right)
+    val componentConfig = resolution.right.get.configurations.find(_.configuration == Compile.toConfigRef).get
+    val compress = componentConfig.modules.find(_.module.name == "commons-compress").get
+    compress.licenses should have size 1
+  }
 }


### PR DESCRIPTION
In addition to the unit test, tested by running the scripted tests on the `use-update` branch of `sbt-license-report` at https://github.com/sbt/sbt-license-report/pull/123

Fixes https://github.com/coursier/coursier/issues/1790