### PR TITLE
Revert use of `WeakReference`s for `SbtUpdateReport` cached values

### DIFF
--- a/modules/lm-coursier/src/main/scala/lmcoursier/internal/SbtUpdateReport.scala
+++ b/modules/lm-coursier/src/main/scala/lmcoursier/internal/SbtUpdateReport.scala
@@ -1,7 +1,6 @@
 package lmcoursier.internal
 
 import java.io.File
-import java.lang.ref.WeakReference
 import java.net.URL
 import java.util.{Collections, GregorianCalendar, WeakHashMap}
 import coursier.cache.CacheUrl
@@ -17,16 +16,16 @@ import scala.annotation.tailrec
 private[internal] object SbtUpdateReport {
 
   private def caching[K, V](f: K => V): K => V = {
-    val cache = Collections.synchronizedMap(new WeakHashMap[K, WeakReference[V]])
+    val cache = Collections.synchronizedMap(new WeakHashMap[K, V])
 
     key =>
       val previousValueOpt = Option(cache.get(key))
 
-      previousValueOpt.fold {
+      previousValueOpt.getOrElse {
         val value = f(key)
-        val concurrentValueOpt = Option(cache.putIfAbsent(key, new WeakReference(value)))
-        concurrentValueOpt.fold(value)(_.get())
-      }(_.get())
+        val concurrentValueOpt = Option(cache.putIfAbsent(key, value))
+        concurrentValueOpt.getOrElse(value)
+      }
   }
 
   private def infoProperties(project: Project): Seq[(String, String)] =


### PR DESCRIPTION
Fixes sbt/sbt#8150

In #563, I chose to wrap the cache map's values in `WeakReference` because in heap dumps I was seeing a lot of `sbt.librarymanagement.Artifact` and `sbt.librarymanagement.ModuleID`s mentioned as values that `SbtUpdateReport` was referencing. Using `WeakReference` caused them to go away.

The result of using it is that the map's values could be garbage collected before its keys, leading to map entries with `null` values and causing `NullPointerException`s.

Looking more closely at the heap dumps, I don't think the `Artifact`s and `ModuleID`s are part of the original memory leak issue, so it should be fine to remove `WeakReference`. Without `WeakReference` the number of them doesn't grow linearly with the number of updates, nor does the retained heap of `SbtUpdateReport`.

@eed3si9n do you mind taking a look?