### PR TITLE
Build coursier 2.12 modules from sources on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,21 @@ on:
   pull_request:
 
 jobs:
+  coursier-snapshot:
+    name: coursier snapshot
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - uses: coursier/cache-action@v8.1
+    - name: Build and publish coursier locally
+      run: scripts/publish-local-coursier.sh
+      shell: bash
+    - uses: actions/upload-artifact@v7
+      with:
+        name: m2-repo
+        path: m2-repo
+        if-no-files-found: error
+
   formatting:
     runs-on: ubuntu-latest
     steps:
@@ -22,6 +37,7 @@ jobs:
     - run: sbt scalafmtCheckAll
 
   test:
+    needs: coursier-snapshot
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -43,11 +59,18 @@ jobs:
       with:
         jvm: 8
         apps: sbt
+    # m2-repo is the maven repository the build resolves the coursier modules
+    # from (see build.sbt)
+    - name: Get the coursier snapshot
+      uses: actions/download-artifact@v8
+      with:
+        name: m2-repo
+        path: m2-repo
     - run: scripts/ci.sh
       shell: bash
 
   publish:
-    needs: test
+    needs: [coursier-snapshot, test]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
@@ -61,6 +84,11 @@ jobs:
           jvm: 8
           apps: sbt
       - uses: olafurpg/setup-gpg@v3
+      - name: Get the coursier snapshot
+        uses: actions/download-artifact@v8
+        with:
+          name: m2-repo
+          path: m2-repo
       - name: Release
         run: sbt ci-release
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ metals.sbt
 
 # Intellij
 .idea/
+
+# coursier modules built from sources by scripts/publish-local-coursier.sh
+/m2-repo/

--- a/build.sbt
+++ b/build.sbt
@@ -15,13 +15,25 @@ inThisBuild(List(
     )
   ),
   Test / fork := true,
+  // jline, pulled by librarymanagement-ivy, calls jansi 1.x APIs from its Windows
+  // terminal. Since coursier 2.1.25-M26, coursier-cache pulls jansi 2.x (via
+  // windows-ansi 0.0.6), which doesn't have those any more, and wins over the
+  // jansi classes jline bundles. Keep jline away from the terminal in tests, else
+  // they crash on Windows with
+  // NoSuchMethodError: org.fusesource.jansi.AnsiConsole.wrapOutputStream
+  Test / javaOptions += "-Djline.terminal=none",
   semanticdbEnabled := true,
   semanticdbVersion := "4.13.10",
   scalafixDependencies += "net.hamnaberg" %% "dataclass-scalafix" % dataclassScalafixV,
-  libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % "always"
+  libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % "always",
+  // the coursier modules we depend on are built from sources and published there
+  // by scripts/publish-local-coursier.sh
+  resolvers += MavenCache("coursier-snapshot", (ThisBuild / baseDirectory).value / "m2-repo")
 ))
 
-def coursierVersion0 = "2.1.23"
+// coursier version published locally by scripts/publish-local-coursier.sh (from the
+// coursier sources, at the tag pinned there)
+def coursierVersion0 = "SNAPSHOT"
 def coursierDep = ("io.get-coursier" %% "coursier" % coursierVersion0)
   .exclude("org.codehaus.plexus", "plexus-archiver")
   .exclude("org.codehaus.plexus", "plexus-container-default")

--- a/scripts/publish-local-coursier.sh
+++ b/scripts/publish-local-coursier.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Builds coursier from sources, and publishes locally the coursier modules that
+# the sbt-coursier build depends on.
+#
+# The coursier sources are checked out at the tag below, and an empty commit,
+# tagged "vSNAPSHOT", is added on top of it. That way, coursier's build computes
+# "SNAPSHOT" as version, rather than the version of the release tag. As snapshots
+# are not published on Maven Central, this ensures that the modules the
+# sbt-coursier build resolves are the ones published by this script in m2-repo,
+# and not artifacts fetched from Maven Central.
+#
+# COURSIER_TAG below is meant to be bumped when a newer coursier version is
+# needed. The version the sbt-coursier build depends on (coursierVersion0 in
+# build.sbt) stays "SNAPSHOT".
+
+COURSIER_GIT_URL="${COURSIER_GIT_URL:-https://github.com/coursier/coursier.git}"
+COURSIER_TAG="${COURSIER_TAG:-v2.1.25-M26}"
+SCALA_VERSION="${SCALA_VERSION:-2.12.20}"
+
+# coursier's build strips the leading "v" of the tag of the current commit, and
+# uses that as version
+SNAPSHOT_TAG="vSNAPSHOT"
+COURSIER_VERSION="${SNAPSHOT_TAG#v}"
+
+# coursier modules needed to build sbt-coursier: the ones the sbt-coursier build
+# depends on (coursier, coursier-sbt-maven-repository), and their dependencies
+# (mill only publishes the modules it's asked to publish).
+MODULES=(
+  "util.jvm[$SCALA_VERSION]"
+  "core.jvm[$SCALA_VERSION]"
+  "cache-util"
+  "paths"
+  "cache.jvm[$SCALA_VERSION]"
+  "proxy-setup"
+  "coursier.jvm[$SCALA_VERSION]"
+  "sbt-maven-repository.jvm[$SCALA_VERSION]"
+)
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# under target/, so that it's ignored by git
+WORK_DIR="${COURSIER_WORK_DIR:-$ROOT/target/coursier-sources}"
+# the maven repository the coursier modules are published to, and that the
+# sbt-coursier build resolves them from (see build.sbt)
+M2_REPO="${M2_REPO:-$ROOT/m2-repo}"
+
+if [ -d "$WORK_DIR/.git" ]; then
+  echo "Re-using coursier checkout in $WORK_DIR"
+else
+  rm -rf "$WORK_DIR"
+  mkdir -p "$(dirname "$WORK_DIR")"
+  git clone \
+    --depth 1 \
+    --branch "$COURSIER_TAG" \
+    --recurse-submodules \
+    --shallow-submodules \
+    "$COURSIER_GIT_URL" \
+    "$WORK_DIR"
+
+  # user.name / user.email are passed explicitly, as git might not be configured
+  # at all where this runs (CI…)
+  git -C "$WORK_DIR" \
+    -c "user.name=sbt-coursier" \
+    -c "user.email=sbt-coursier@localhost" \
+    commit --allow-empty -m "Empty commit, so that a snapshot version is computed"
+  git -C "$WORK_DIR" tag "$SNAPSHOT_TAG"
+fi
+
+EXPECTED_VERSION="$(sed -n 's/^def coursierVersion0 = "\(.*\)"$/\1/p' "$ROOT/build.sbt")"
+if [ "$COURSIER_VERSION" != "$EXPECTED_VERSION" ]; then
+  echo "Warning: the sbt-coursier build uses coursier $EXPECTED_VERSION," 1>&2
+  echo "but this script publishes $COURSIER_VERSION." 1>&2
+  echo "Update coursierVersion0 in build.sbt to \"$COURSIER_VERSION\"." 1>&2
+fi
+
+# the mill launcher script only supports Linux and macOS, Windows needs mill.bat
+case "$(uname -s)" in
+  Linux*|Darwin*) MILL="./mill" ;;
+  *)              MILL="./mill.bat" ;;
+esac
+
+cd "$WORK_DIR"
+for module in "${MODULES[@]}"; do
+  "$MILL" "$module.publishM2Local" --m2RepoPath "$M2_REPO"
+done
+
+echo "Published coursier $COURSIER_VERSION to $M2_REPO"


### PR DESCRIPTION
These shouldn't be published any more, but the coursier sources should still allow to build them for the time being